### PR TITLE
Fix for function return value speculation

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -2094,6 +2094,10 @@ static void ProcessScriptFunc(symbolNode_t *sym, boolean discardReturn)
 	int argCount;
 
 	MS_Message(MSG_DEBUG, "---- ProcessScriptFunc ----\n");
+	if(sym->info.scriptFunc.predefined == YES && discardReturn == NO)
+	{
+		sym->info.scriptFunc.hasReturnValue = YES;
+	}
 	argCount = sym->info.scriptFunc.argCount;
 	TK_NextTokenMustBe(TK_LPAREN, ERR_MISSING_LPAREN);
 	i = 0;
@@ -3678,7 +3682,8 @@ static void ExprFactor(void)
 				ProcessInternFunc(sym);
 				break;
 			case SY_SCRIPTFUNC:
-				if(sym->info.scriptFunc.hasReturnValue == NO)
+				if(sym->info.scriptFunc.predefined == NO
+					&& sym->info.scriptFunc.hasReturnValue == NO)
 				{
 					ERR_Error(ERR_EXPR_FUNC_NO_RET_VAL, YES);
 				}


### PR DESCRIPTION
###### Problem
When a function call is encountered before the function is defined, the compiler speculates its return type based on this first call but never reevaluates the assumption for subsequent calls that may still follow before the definition. This can lead to unwarranted and confusing ERR_EXPR_FUNC_NO_RET_VAL errors if the first call to the function discards the return value, thus sets hasReturnValue to 'false', and calls requiring a return value are then made after the first call and before the definition of the funtion. The errors are raised even if the definition clearly states that the function does return a value.

###### Solution
Do not raise the pointless ERR_EXPR_FUNC_NO_RET_VAL errors for speculated functions as there is no way we can tell whether they return a value or not until we actually reach the definition; and set the hasReturnValue flag for a speculated function to 'true' when a call requiring a return value is made. This way, compilation of speculated functinos only fails when we call them as returning a value and the definition says they don't, which leads to a perfectly valid ERR_PREVIOUS_NOT_VOID.

An example to test with can be found in the related [ZDoom forums post](http://forum.zdoom.org/viewtopic.php?f=7&t=45548).

I can see no side effects and there have been no issues during testing, but mind that this has been my first experience with the acc source.