### PR TITLE
Update zdefs.acs with shadow and subtract styles.

### DIFF
--- a/zdefs.acs
+++ b/zdefs.acs
@@ -1,4 +1,3 @@
-
 //**************************************************************************
 //**
 //** zdefs.acs
@@ -297,12 +296,14 @@
 #define STYLE_Normal		1	// Normal; just copy the image to the screen
 #define STYLE_Fuzzy			2	// Draw silhouette using "fuzz" effect
 #define STYLE_SoulTrans		3	// Draw translucent with amount in r_transsouls
-#define STYLE_OptFuzzy		4	// Draw as fuzzy or translucent, based on user preference
+#define STYLE_OptFuzzy		4	// Draw as fuzzy, translucent or shadow, based on user preference
 #define STYLE_Stencil		5	// Draw as solid color
 #define STYLE_Translucent	64	// Draw translucent
 #define STYLE_Add			65	// Draw additive
 #define STYLE_Shaded		66	// 
 #define STYLE_TranslucentStencil 67
+#define STYLE_Shadow		68	// Draw dark translucent stencil
+#define STYLE_Subtract  69  // Draw subtractive
 
 // Properties you can use with GetLevelInfo() -------------------------------
 


### PR DESCRIPTION
I'm not sure why the values jump from 1, 2, 3, 4, 5 to 64, 65, 66, 67, but I continued from there. Adding shadow is necessary to add subtract.

This is a companion to pull request n°53 on rheit/zdoom.
