### PR TITLE
Fix compilation on OS X and other systems without <malloc.h>

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -10,7 +10,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-#include <malloc.h>
 #include <stdio.h>
 #include <assert.h>
 

--- a/strlist.c
+++ b/strlist.c
@@ -8,7 +8,7 @@
 // HEADER FILES ------------------------------------------------------------
 
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "common.h"
 #include "strlist.h"
 #include "error.h"


### PR DESCRIPTION
All required declarations are in <stdlib.h>
