### PR TITLE
Added FHF_NOIMPACTDECAL flag to zdefs.acs

### DIFF
--- a/zdefs.acs
+++ b/zdefs.acs
@@ -982,6 +982,7 @@
 #define CSF_NOBLOCKALL 2
 
 #define FHF_NORANDOMPUFFZ	1
+#define FHF_NOIMPACTDECAL	2
 
 // Actor flags
 #define MF_SPECIAL          0x00000001


### PR DESCRIPTION
This is the newly added flag for LineAttack function (rheit/zdoom@405fc31e817d4cbbdc60c0bdf73205c6c007559a).