### PR TITLE
Fix wrong function index on some recursive calls

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -825,8 +825,18 @@ static void OuterFunction(void)
 	else
 	{
 		sym = SY_InsertGlobal(tk_String, SY_SCRIPTFUNC);
-		sym->info.scriptFunc.address = (importing == IMPORT_Importing ? 0 : pc_Address);
-		sym->info.scriptFunc.predefined = NO;
+		if (importing == IMPORT_Importing)
+		{
+			sym->info.scriptFunc.address = 0;
+			sym->info.scriptFunc.predefined = NO;
+		}
+		else
+		{
+			sym->info.scriptFunc.address = pc_Address;
+			sym->info.scriptFunc.predefined = YES;
+			// only for consistency with other speculated functions and pretty logs
+			sym->info.scriptFunc.funcNumber = 0;
+		}
 	}
 	defLine = tk_Line;
 


### PR DESCRIPTION
Acc can write wrong function index for recursive calls under certain circumstances which can lead to anything from an out-of-range error and termination of execution of the function to acs stack corruption and an engine crash.

- problem: function index for recursive calls does not get updated in
  cases when the definition of the function comes before its use
- solution: treat the function as predefined until we process the whole
  of its body so that a ref gets added if a recusive call is encountered

Example acs code:
```c
function void offset(void) {
}

function void recursive(void) {
	recursive(); // the function index of this call will be wrong 
}

function void ok(void) {
	recursive();
}
```

Acc debug log before the fix (byte 000010 is garbage and won't get updated):
```
Add include path 1: "./"
Program include path is 2: "C:\BACKUP\Dev\DooM\acc\Debug\"
AS> 000000 = "ACS" (4 bytes)
SL> 000004 (skip int)
---- OuterFunction ----
Freeing local identifiers
Inserting global identifier: offset (SY_SCRIPTFUNC)
AC> 000008 = #205:PCD_RETURNVOID
Adding string 0:
  "offset"
---- OuterFunction ----
Freeing local identifiers
Inserting global identifier: recursive (SY_SCRIPTFUNC)
---- ProcessScriptFunc ----
AC> 000009 = #204:PCD_CALLDISCARD
AB> 000010 = 205
AC> 000011 = #205:PCD_RETURNVOID
Adding string 1:
  "recursive"
---- OuterFunction ----
Freeing local identifiers
Inserting global identifier: ok (SY_SCRIPTFUNC)
---- ProcessScriptFunc ----
AC> 000012 = #204:PCD_CALLDISCARD
AB> 000013 = 1
AC> 000014 = #205:PCD_RETURNVOID
Adding string 2:
  "ok"
---- PC_CloseObject ----
AB> 000015 = 0
Creating dummy scripts to make WadAuthor happy.
AD> 000016 = (4 bytes)
AL> 000020 = 24
Function 0:offset, address = 8, arg count = 0, var count = 0
AB> 000024 = 0
AB> 000025 = 0
AB> 000026 = 0
AB> 000027 = 0
AL> 000028 = 8
Function 1:recursive, address = 9, arg count = 0, var count = 0
AB> 000032 = 0
AB> 000033 = 0
AB> 000034 = 0
AB> 000035 = 0
AL> 000036 = 9
Function 2:ok, address = 12, arg count = 0, var count = 0
AB> 000040 = 0
AB> 000041 = 0
AB> 000042 = 0
AB> 000043 = 0
AL> 000044 = 12
---- STR_WriteListChunk 1 FNAM----
AL> 000048 = 1296125510
SL> 000052 (skip int)
AL> 000056 = 3
AL> 000060 = 16
AL> 000064 = 23
AL> 000068 = 33
AS> 000072 = "offset" (7 bytes)
AS> 000079 = "recursive" (10 bytes)
AS> 000089 = "ok" (3 bytes)
WL> 000052 = 36
AL> 000092 = 16
AD> 000096 = (4 bytes)
WL> 000004 = 100
AL> 000100 = 0
AL> 000104 = 0
```

Acc debug log after the fix:
```
Add include path 1: "./"
Program include path is 2: "C:\BACKUP\Dev\DooM\acc\git\Debug\"
AS> 000000 = "ACS" (4 bytes)
SL> 000004 (skip int)
---- OuterFunction ----
Freeing local identifiers
Inserting global identifier: offset (SY_SCRIPTFUNC)
AC> 000008 = #205:PCD_RETURNVOID
Adding string 0:
  "offset"
---- OuterFunction ----
Freeing local identifiers
Inserting global identifier: recursive (SY_SCRIPTFUNC)
---- ProcessScriptFunc ----
AC> 000009 = #204:PCD_CALLDISCARD
AB> 000010 = 0
AC> 000011 = #205:PCD_RETURNVOID
Adding string 1:
  "recursive"
WB> 000010 = 1
---- OuterFunction ----
Freeing local identifiers
Inserting global identifier: ok (SY_SCRIPTFUNC)
---- ProcessScriptFunc ----
AC> 000012 = #204:PCD_CALLDISCARD
AB> 000013 = 1
AC> 000014 = #205:PCD_RETURNVOID
Adding string 2:
  "ok"
---- PC_CloseObject ----
AB> 000015 = 0
Creating dummy scripts to make WadAuthor happy.
AD> 000016 = (4 bytes)
AL> 000020 = 24
Function 0:offset, address = 8, arg count = 0, var count = 0
AB> 000024 = 0
AB> 000025 = 0
AB> 000026 = 0
AB> 000027 = 0
AL> 000028 = 8
Function 1:recursive, address = 9, arg count = 0, var count = 0
AB> 000032 = 0
AB> 000033 = 0
AB> 000034 = 0
AB> 000035 = 0
AL> 000036 = 9
Function 2:ok, address = 12, arg count = 0, var count = 0
AB> 000040 = 0
AB> 000041 = 0
AB> 000042 = 0
AB> 000043 = 0
AL> 000044 = 12
---- STR_WriteListChunk 1 FNAM----
AL> 000048 = 1296125510
SL> 000052 (skip int)
AL> 000056 = 3
AL> 000060 = 16
AL> 000064 = 23
AL> 000068 = 33
AS> 000072 = "offset" (7 bytes)
AS> 000079 = "recursive" (10 bytes)
AS> 000089 = "ok" (3 bytes)
WL> 000052 = 36
AL> 000092 = 16
AD> 000096 = (4 bytes)
WL> 000004 = 100
AL> 000100 = 0
AL> 000104 = 0
```