### PR TITLE
Fixed so compilation works on Mac

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -12,7 +12,7 @@
 #else
 #include <fcntl.h>
 #include <stdlib.h>
-#ifndef unix
+#if !defined(unix) && !defined(__APPLE__)
 #include <io.h>
 #endif
 #endif

--- a/token.c
+++ b/token.c
@@ -15,7 +15,7 @@
 #ifdef __NeXT__
 #include <libc.h>
 #else
-#ifndef unix
+#if !defined(unix) && !defined(__APPLE__)
 #include <io.h>
 #endif
 #include <limits.h>


### PR DESCRIPTION
It seems that a user-defined "unix" macro is checked whether to include the DOS/Windows/Microsoft specific \<io.h\> file. That macro isn't used anywhere in a Makefile. Regardless, I added an \_\_APPLE\_\_ check wherever \<io.h\> would be included. This may require modifications to compile on Linux too, where I believe there _is_ a system-set Unix macro (which I believe Apple doesn't recognize despite being UNIX).