### PR TITLE
Fixed: #region blocks should not increase outertokencount (otherwise …

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -522,6 +522,7 @@ static void Outside(void)
 				break;
 			case TK_REGION: // [mxd]
 			case TK_ENDREGION:
+				outertokencount--; // #region markers should not count as "real" tokens
 				TK_SkipLine();
 				break;
 			default:


### PR DESCRIPTION
…#library inside a #region will generate the ERR_LIBRARY_NOT_FIRST error).