### PR TITLE
Fixed: TK_SkipLine() got stuck in an infinite loop when previous toke…

### DIFF
--- a/token.c
+++ b/token.c
@@ -1573,5 +1573,5 @@ void TK_SkipLine(void)
 {
 	char *sourcenow = tk_SourceName;
 	int linenow = tk_Line;
-	do TK_NextToken(); while (tk_Line == linenow && tk_SourceName == sourcenow);
+	do TK_NextToken(); while (tk_Line == linenow && tk_SourceName == sourcenow && tk_Token != TK_EOF);
 }


### PR DESCRIPTION
…n (like #endregion...) was at the end of the file.