### PR TITLE
Added KILL script type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /log
 /t
 /zdefs.acs.orig
+/*.o

--- a/parse.c
+++ b/parse.c
@@ -341,6 +341,7 @@ static struct ScriptTypes ScriptCounts[] =
 	{ "unloading",		UNLOADING_SCRIPTS_BASE,		0 },
 	{ "return",			RETURN_SCRIPTS_BASE,		0 },
 	{ "event",			EVENT_SCRIPTS_BASE,			0 },
+	{ "kill",			KILL_SCRIPTS_BASE,			0 },
 	{ NULL,				-1,							0 }
 };
 
@@ -670,6 +671,7 @@ static void OuterScript(void)
 		case TK_LIGHTNING:
 		case TK_UNLOADING:
 		case TK_RETURN:
+		case TK_KILL:
 			ERR_Error(ERR_UNCLOSED_WITH_ARGS, YES);
 			break;
 
@@ -742,6 +744,10 @@ static void OuterScript(void)
 	case TK_EVENT:	// [BB]
 		scriptType = EVENT_SCRIPTS_BASE;
 		ERR_Error (ERR_EVENT_NEEDS_3_ARG, YES);
+		break;
+		
+	case TK_KILL: // [JM]
+		scriptType = KILL_SCRIPTS_BASE;
 		break;
 
 	default:

--- a/pcode.h
+++ b/pcode.h
@@ -31,6 +31,7 @@ enum
 	DISCONNECT_SCRIPTS_BASE		= 14,
 	RETURN_SCRIPTS_BASE			= 15,
 	EVENT_SCRIPTS_BASE			= 16,	// [BB]
+	KILL_SCRIPTS_BASE			= 17,	// [JM]
 };
 
 // Values to indicate script flags (requires new-style .o)

--- a/token.c
+++ b/token.c
@@ -199,6 +199,7 @@ static struct keyword_s
 	{ "strcpy", TK_STRCPY }, // [FDARI]
 	{ "region", TK_REGION }, // [mxd]
 	{ "endregion", TK_ENDREGION }, // [mxd]
+	{ "kill", TK_KILL }, // [JM]
 };
 
 #define NUM_KEYWORDS (sizeof(Keywords)/sizeof(Keywords[0]))

--- a/token.h
+++ b/token.h
@@ -134,6 +134,7 @@ typedef enum
 	TK_STRCPY,          // 'strcpy'
 	TK_REGION,			// 'region' [mxd]
 	TK_ENDREGION,		// 'endregion' [mxd]
+	TK_KILL,			// 'kill' [JM]
 } tokenType_t;
 
 // PUBLIC FUNCTION PROTOTYPES ----------------------------------------------


### PR DESCRIPTION
Added /*.o to .gitignore as well. We don't want people accidentally
committing object files from their compiles, now do we?

Anyhow, this is meant to accompany the KILL scripts push request for ZDoom. Link: https://github.com/rheit/zdoom/pull/745