### PR TITLE
Add CheckActorState

### DIFF
--- a/zspecial.acs
+++ b/zspecial.acs
@@ -366,6 +366,7 @@ special
 	-96:SpawnParticle(1,16),
 	-97:SetMusicVolume(1),
 	-98:CheckProximity(3, 6),
+	-99:CheckActorState(2,3),
 	
 	// Zandronum's
 	-100:ResetMap(0),


### PR DESCRIPTION
bool CheckActorState(int tid, str statename, bool exact = false);

- Same parameter order as SetActorState
- Returns true if actor has the state; else returns false

This is to fulfill the feature requested by Blue Shadow [here](http://forum.zdoom.org/viewtopic.php?f=15&t=53268).