### PR TITLE
Add SetAirFriction for Eternity

### DIFF
--- a/zspecial.acs
+++ b/zspecial.acs
@@ -427,6 +427,7 @@ special
 	// Eternity's
 	-300:GetLineX(3),
 	-301:GetLineY(3),
+    -302:SetAirFriction(1),
 	
 	// GZDoom OpenGL
 	-400:SetSectorGlow(6),

--- a/zspecial.acs
+++ b/zspecial.acs
@@ -427,7 +427,7 @@ special
 	// Eternity's
 	-300:GetLineX(3),
 	-301:GetLineY(3),
-    -302:SetAirFriction(1),
+	-302:SetAirFriction(1),
 	
 	// GZDoom OpenGL
 	-400:SetSectorGlow(6),


### PR DESCRIPTION
It was added in Eternity to limit the maximum speed one can reach especially if air control is too high.