### PR TITLE
Add ternary operator syntax

### DIFF
--- a/token.c
+++ b/token.c
@@ -1327,6 +1327,9 @@ static void ProcessSpecialToken(void)
 		case ']':
 			tk_Token = TK_RBRACKET;
 			break;
+		case '?':
+			tk_Token = TK_TERNARY;
+			break;
 		case ':':
 			tk_Token = TK_COLON;
 			break;

--- a/token.h
+++ b/token.h
@@ -58,6 +58,7 @@ typedef enum
 	TK_RBRACE,			// '}'
 	TK_LBRACKET,		// '['
 	TK_RBRACKET,		// ']'
+	TK_TERNARY,			// '?'
 	TK_COLON,			// ':'
 	TK_SEMICOLON,		// ';'
 	TK_COMMA,			// ','


### PR DESCRIPTION
This PR adds the ternary operator present in other C-like languages.
Example:
```
function int myAbs(int x)
{
    return x > 0 ? x : -x;
}

Script 1 (void)
{
    Log(s:GetActorProperty(0, APROP_Health) > 50 ? "You're OK" : "You should heal up");
}
```