### PR TITLE
Added error display when declaring an array with negative size

### DIFF
--- a/error.c
+++ b/error.c
@@ -181,6 +181,7 @@ static struct
 	{ ERR_SPECIAL_RANGE, "Line specials with values higher than 255 require #nocompact." },
 	{ ERR_EVENT_NEEDS_3_ARG, "Event scripts must have 3 arguments." }, // [BB]
 	{ ERR_LIBRARY_NOT_FIRST, "#library must come before anything else." },
+	{ ERR_NEGATIVE_ARRAY_SIZE, "Overall array size must be positive but less than 2^31" },
 	{ ERR_NONE, NULL }
 };
 

--- a/error.h
+++ b/error.h
@@ -149,6 +149,7 @@ typedef enum
 	ERR_SPECIAL_RANGE,
 	ERR_EVENT_NEEDS_3_ARG, // [BB]
 	ERR_LIBRARY_NOT_FIRST,
+	ERR_NEGATIVE_ARRAY_SIZE,
 } error_t;
 
 // PUBLIC FUNCTION PROTOTYPES ----------------------------------------------

--- a/parse.c
+++ b/parse.c
@@ -4211,6 +4211,12 @@ static void ParseArrayDims(int *size_p, int *ndim_p, int dims[MAX_ARRAY_DIMS])
 		ERR_Error(ERR_HEXEN_COMPAT, YES);
 		TK_NextToken();
 	}
+	if(size < 0)
+	{
+		TK_Undo(); // backup so error pointer is on last bracket instead of following token
+		ERR_Error(ERR_NEGATIVE_ARRAY_SIZE, YES);
+		TK_NextToken();
+	}
 	*size_p = size;
 	*ndim_p = ndim;
 }


### PR DESCRIPTION
When addressing an array, GZDoom reads the index as a signed number. Then performs an unsigned comparison with array size which covers both the numbers which greater than array size and numbers which lesser than zero since every negative number will be greater than any positive number with an unsigned comparison.

But ACC allows creating arrays with negative size. It allows the script to bypass unsigned comparison and get access to the memory with the negative offset from the pointer to the beginning of the array which may lead to undefined behavior.

So banned arrays with negative size and added error display for the user.