### PR TITLE
- restored correct limit on number of functions

### DIFF
--- a/common.h
+++ b/common.h
@@ -50,7 +50,7 @@
 // Added Ty 07Jan2000 for error details
 #define MAX_STATEMENT_LENGTH 4096
 
-#define MAX_FUNCTION_COUNT 8192
+#define MAX_FUNCTION_COUNT 256
 
 #define MAX_IMPORTS 256
 


### PR DESCRIPTION
It's not possible to have more that 256 functions in one module because function number is stored in one byte at call site

This reverts commit 290a8a0b23e9428ac70af6220c57d8a892a4c4a8.

https://forum.zdoom.org/viewtopic.php?t=69374&p=1160180#p1160180
