### PR TITLE
Fixed bug with required optional parameters of MorphActor function

### DIFF
--- a/symbol.c
+++ b/symbol.c
@@ -193,7 +193,6 @@ static internFuncDef_t InternalFunctions[] =
 	{ "thingcountsector", PCD_NOP, PCD_THINGCOUNTSECTOR, 3, 0, 0, YES, NO },
 	{ "thingcountnamesector", PCD_NOP, PCD_THINGCOUNTNAMESECTOR, 3, 0, 0, YES, NO },
 	{ "checkplayercamera", PCD_NOP, PCD_CHECKPLAYERCAMERA, 1, 0, 0, YES, NO },
-	{ "morphactor", PCD_NOP, PCD_MORPHACTOR, 7, 2|4|8|16|32|64, 0, YES, NO },
 	{ "unmorphactor", PCD_NOP, PCD_UNMORPHACTOR, 2, 2, 0, YES, NO },
 	{ "getplayerinput", PCD_NOP, PCD_GETPLAYERINPUT, 2, 0, 0, YES, NO },
 	{ "classifyactor", PCD_NOP, PCD_CLASSIFYACTOR, 1, 0, 0, YES, NO },

--- a/token.c
+++ b/token.c
@@ -201,6 +201,7 @@ static struct keyword_s
 	{ "endregion", TK_ENDREGION }, // [mxd]
 	{ "kill", TK_KILL }, // [JM]
 	{ "reopen", TK_REOPEN }, // [Nash]
+	{ "morphactor", TK_MORPHACTOR }, // [Dasperal]
 };
 
 #define NUM_KEYWORDS (sizeof(Keywords)/sizeof(Keywords[0]))

--- a/token.h
+++ b/token.h
@@ -138,6 +138,7 @@ typedef enum
 	TK_KILL,			// 'kill' [JM]
 	TK_REOPEN,			// 'reopen' [Nash]
 	TK_ATSIGN,			// '@'
+	TK_MORPHACTOR,		// 'morphactor' [Dasperal]
 } tokenType_t;
 
 // PUBLIC FUNCTION PROTOTYPES ----------------------------------------------


### PR DESCRIPTION
Fix of the issue described in [wiki entry](https://zdoom.org/wiki/MorphActor) for MorphActor function.
Optional string arguments are now encoded as an empty string instead of zero.