### PR TITLE
Add Polyobj_StopSound special

### DIFF
--- a/zspecial.acs
+++ b/zspecial.acs
@@ -277,6 +277,7 @@ special
 	280:Ceiling_MoveToValueAndCrush(4, 5),
 	281:Line_SetAutomapFlags(3),
 	282:Line_SetAutomapStyle(2),
+	283:Polyobj_StopSound(1),
 	
 	// new to Eternity
 //	300:Portal_Define(5),
@@ -445,4 +446,3 @@ special
 	-19621:SetTeamScore(2),
 	
 	-100000:__EndOfList__(10);
-	


### PR DESCRIPTION
This PR adds Polyobj_StopSound special that stops the sound being played by the polyobject.

Related GZDoom pull request: https://github.com/coelckers/gzdoom/pull/1244