### PR TITLE
Add SDF_FIXED_ZOFF and SDF_FIXED_DISTANCE definitions for SpawnDecal

### DIFF
--- a/zdefs.acs
+++ b/zdefs.acs
@@ -747,6 +747,8 @@
 
 #define SDF_ABSANGLE			1
 #define SDF_PERMANENT			2
+#define SDF_FIXED_ZOFF			4
+#define SDF_FIXED_DISTANCE		8
 
 // Actor pointer selectors
 


### PR DESCRIPTION
These are the new definitions to go with the GZDoom change in coelckers/gzdoom#1365.